### PR TITLE
update to latest error prone to remove protobuf-java@3.19.2 vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
     implementation("org.openrewrite:rewrite-templating:$rewriteVersion")
 
     annotationProcessor("org.openrewrite:rewrite-templating:$rewriteVersion")
-    compileOnly("com.google.errorprone:error_prone_core:2.19.1") {
+    compileOnly("com.google.errorprone:error_prone_core:2.+") {
         exclude("com.google.auto.service", "auto-service-annotations")
     }
     implementation("io.projectreactor:reactor-core:latest.release")


### PR DESCRIPTION
Related to: https://github.com/moderneinc/dependency-vulnerability-reports/issues/741